### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -14,7 +14,8 @@
     "ejs": "^3.1.10",
     "express": "^4.22.1",
     "moment": "^2.29.4",
-    "mongoose": "^8.9.5"
+    "mongoose": "^8.9.5",
+    "express-rate-limit": "^8.3.2"
   },
   "devDependencies": {
     "connect-livereload": "^0.6.1",

--- a/app/routes/front.js
+++ b/app/routes/front.js
@@ -1,10 +1,16 @@
 const express = require('express');
+const rateLimit = require('express-rate-limit');
 const Todo = require('./../models/Todo');
 
 const router = express.Router();
 
+const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100 // limit each IP to 100 requests per windowMs
+});
+
 // Home page route
-router.get('/', async (req, res) => {
+router.get('/', limiter, async (req, res) => {
 
     const todos = await Todo.find()
     res.render("todos", {
@@ -13,7 +19,7 @@ router.get('/', async (req, res) => {
 });
 
 // POST - Submit Task
-router.post('/', (req, res) => {
+router.post('/', limiter, (req, res) => {
     const newTask = new Todo({
         task: req.body.task
     });
@@ -24,7 +30,7 @@ router.post('/', (req, res) => {
 });
 
 // POST - Destroy todo item
-router.post('/todo/destroy', async (req, res) => {
+router.post('/todo/destroy', limiter, async (req, res) => {
     const taskKey = req.body._key;
     const err = await Todo.findOneAndRemove({_id: taskKey})
     res.redirect('/');


### PR DESCRIPTION
Potential fix for [https://github.com/cryptoinsider1/multi-container-app/security/code-scanning/1](https://github.com/cryptoinsider1/multi-container-app/security/code-scanning/1)

Add a rate-limiting middleware to `app/routes/front.js` and apply it to the routes that hit the database. The best fix without changing functionality is to use the well-known `express-rate-limit` package, define a limiter once near the router setup, and attach it to `GET /`, `POST /`, and `POST /todo/destroy`. This preserves existing route behavior while preventing abuse by limiting request volume per IP over a time window.

Concretely in `app/routes/front.js`:
- Add `const rateLimit = require('express-rate-limit');` near existing imports.
- Define a limiter instance after `const router = express.Router();`.
- Pass the limiter as middleware in each database-backed route:
  - `router.get('/', limiter, async (...) => {...})`
  - `router.post('/', limiter, (...) => {...})`
  - `router.post('/todo/destroy', limiter, async (...) => {...})`


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
